### PR TITLE
Fix Javalin 6.x compatibility and Docker ARM64 support

### DIFF
--- a/account-event-producer/src/main/java/io/confluent/csid/data/governance/lineage/opentel/transactiondemo/accountproducer/AccountEventService.java
+++ b/account-event-producer/src/main/java/io/confluent/csid/data/governance/lineage/opentel/transactiondemo/accountproducer/AccountEventService.java
@@ -1,11 +1,11 @@
 package io.confluent.csid.data.governance.lineage.opentel.transactiondemo.accountproducer;
 
-import static io.javalin.apibuilder.ApiBuilder.path;
-import static io.javalin.apibuilder.ApiBuilder.post;
-
 import io.confluent.csid.data.governance.lineage.opentel.transactiondemo.common.serde.JsonAccountEventSerde;
 import io.javalin.Javalin;
 import lombok.extern.slf4j.Slf4j;
+
+import static io.javalin.apibuilder.ApiBuilder.path;
+import static io.javalin.apibuilder.ApiBuilder.post;
 
 @Slf4j
 public class AccountEventService {
@@ -18,27 +18,24 @@ public class AccountEventService {
     ProducerService producerService = new ProducerService();
     JsonAccountEventSerde jsonAccountEventSerde = new JsonAccountEventSerde();
     Javalin app = Javalin.create(config -> {
-      config.enforceSsl = false;
-      config.asyncRequestTimeout = 10_000L;
-
-    }).routes(() -> {
-      path("produce-account-event", () ->
+      config.http.asyncTimeout = 10_000L;
+      config.router.apiBuilder(() -> {
+        path("produce-account-event", () -> {
           post(ctx -> {
             log.info("Account Event: {}", new String(ctx.bodyAsBytes()));
             producerService.produce(jsonAccountEventSerde.deserialize("", ctx.bodyAsBytes()));
             ctx.result("OK");
-          })
-      );
-    });
+          });
+        });
+      });
+    }).start(7070);
 
     Runtime.getRuntime().addShutdownHook(new Thread("account-producer-shutdown-hook") {
       @Override
       public void run() {
         producerService.close();
-        app.close();
-
+        app.stop();
       }
     });
-    app.start(7070);
   }
 }

--- a/demo/docker-compose.yaml
+++ b/demo/docker-compose.yaml
@@ -4,6 +4,7 @@ services:
 
   kafka:
     image: confluentinc/cp-server:6.2.1
+    platform: linux/amd64
     hostname: kafka
     container_name: kafka
     depends_on:
@@ -33,6 +34,7 @@ services:
 
   schema-registry:
     image: confluentinc/cp-schema-registry:6.2.1
+    platform: linux/amd64
     hostname: schema-registry
     container_name: schema-registry
     depends_on:
@@ -46,6 +48,7 @@ services:
 
   control-center:
     image: confluentinc/cp-enterprise-control-center:6.2.1
+    platform: linux/amd64
     hostname: control-center
     container_name: control-center
     depends_on:
@@ -66,6 +69,7 @@ services:
 
   zookeeper:
     image: confluentinc/cp-zookeeper:6.2.1
+    platform: linux/amd64
     environment:
       ZOOKEEPER_CLIENT_PORT: 2181
       ZOOKEEPER_TICK_TIME: 2000
@@ -75,6 +79,7 @@ services:
   # Jaeger
   jaeger:
     image: jaegertracing/all-in-one:latest
+    platform: linux/amd64
     command: ["--query.max-clock-skew-adjustment=0"]
     ports:
       - "16686:16686"
@@ -83,6 +88,7 @@ services:
   # Collector
   otel-collector:
     image: ${OTELCOL_IMG}
+    platform: linux/amd64
     command: [ "--config=/etc/otel-collector-config.yaml", "${OTELCOL_ARGS}" ]
     volumes:
       - ./otel-collector-config.yaml:/etc/otel-collector-config.yaml
@@ -100,6 +106,7 @@ services:
     build:
       dockerfile: Dockerfile
       context: ./javaapps
+    platform: linux/amd64
     depends_on:
       - kafka
       - otel-collector
@@ -107,6 +114,7 @@ services:
   prometheus:
     container_name: prometheus
     image: prom/prometheus:latest
+    platform: linux/amd64
     volumes:
       - ./prometheus.yaml:/etc/prometheus/prometheus.yml
     ports:
@@ -114,6 +122,7 @@ services:
 
   splunk:
     image: splunk/splunk:latest
+    platform: linux/amd64
     container_name: splunk
     environment:
       - SPLUNK_START_ARGS=--accept-license


### PR DESCRIPTION
Based on the changes made to fix the demo, here's an appropriate pull request description:

## Fix Javalin 6.x compatibility and Docker ARM64 support

### Summary
This PR fixes compilation errors and Docker compatibility issues that were preventing the demo from running successfully.

### Changes Made

#### 1. Updated Javalin API usage for version 6.x compatibility
**Files:** 
- `transaction-producer/src/main/java/.../TransactionEventService.java`
- `account-event-producer/src/main/java/.../AccountEventService.java`

**Changes:**
- Removed deprecated `config.enforceSsl` configuration (no longer supported in Javalin 6.x)
- Updated `config.asyncRequestTimeout` to `config.http.asyncTimeout` 
- Moved route definitions from `.routes()` method to `config.router.apiBuilder()` within the `create()` block
- Replaced deprecated `app.close()` with `app.stop()` in shutdown hooks

These changes align with the Javalin 5 to 6 migration guide requirements.

#### 2. Added Docker platform specification for ARM64 compatibility
**File:** `demo/docker-compose.yaml`

**Changes:**
- Added `platform: linux/amd64` to all services to ensure x86 image compatibility on ARM-based systems (Apple Silicon Macs)
- This resolves "no matching manifest for linux/arm64/v8" errors by forcing Docker to use x86 emulation

**Services updated:**
- kafka
- schema-registry  
- control-center
- zookeeper
- jaeger
- otel-collector
- javaapps
- prometheus
- splunk

### Testing
- ✅ Maven build now completes successfully
- ✅ Docker containers start without architecture errors
- ✅ All demo services are accessible at their respective URLs

### Breaking Changes
None - these are compatibility fixes that restore functionality without changing the demo's behavior.